### PR TITLE
Added Dell U2713H to non-working list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Monitors:
 +------------------+---------------+
 | Dell U2415h      | Dell P2412H   |
 +------------------+---------------+
-| Dell U2515h      |               |
+| Dell U2515h      | Dell U2713H   |
 +------------------+---------------+
 | Dell U2715h      |               |
 +------------------+---------------+
@@ -39,9 +39,9 @@ Monitors:
 +------------------+---------------+
 | Samsung SA 350   |               |
 +------------------+---------------+
-| BenQ G2410HD     |               | 
+| BenQ G2410HD     |               |
 +------------------+---------------+
-| Viseo 230Ws      |               | 
+| Viseo 230Ws      |               |
 +------------------+---------------+
 
 If you have tested your monitor(s) with this tool, please let me know whether or not it work and I will update this table.


### PR DESCRIPTION
Dell **U2713H** doesn’t work on the latest OS X (10.11.6) and MBPr (MacBook
Pro Retina, 13-inch, Early 2015).

It can prob `BR` and `CR` values correctly, but can’t set them. Sliders in the menu bar
have no effect on monitors `BR` or `CR`.
