### PR TITLE
Add AOC Q2577PWQ as working monitor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,8 @@ Monitors:
 +------------------+---------------+
 | Viseo 230Ws      |               | 
 +------------------+---------------+
+| AOC Q2577PWQ (DP)|               | 
++------------------+---------------+
 
 If you have tested your monitor(s) with this tool, please let me know whether or not it work and I will update this table.
 


### PR DESCRIPTION
Working only over display port cable (not working over HDMI cable).
